### PR TITLE
Update for not integer collection id root

### DIFF
--- a/metabase-exporter/MetabaseApi.cs
+++ b/metabase-exporter/MetabaseApi.cs
@@ -173,6 +173,7 @@ namespace metabase_exporter
         {
             HttpRequestMessage request() => new HttpRequestMessage(HttpMethod.Get, new Uri("/api/collection", UriKind.Relative));
             var response = await sessionManager.Send(request);
+            response = response.Replace("\"id\":\"root\"", "\"id\":\"0\"");
             return JsonConvert.DeserializeObject<Collection[]>(response);
         }
 


### PR DESCRIPTION
There is collection id "root" in last versions of Metabase. So my fix change this to 0 before json deserialization